### PR TITLE
upgrade mediabunny to 1.28.0 with hardware acceleration

### DIFF
--- a/lib/video-encoding.ts
+++ b/lib/video-encoding.ts
@@ -16,7 +16,8 @@ export const createAvcEncodingConfig = (
   width?: number,
   height?: number,
   codecString: string = AVC_LEVEL_4_0,
-  framerate?: number
+  framerate?: number,
+  useHardwareAcceleration: boolean = true
 ): VideoEncodingConfig => ({
   codec: 'avc',
   bitrate,
@@ -24,6 +25,7 @@ export const createAvcEncodingConfig = (
   bitrateMode: 'variable',
   latencyMode: 'quality',
   fullCodecString: codecString,
+  hardwareAcceleration: useHardwareAcceleration ? 'prefer-hardware' : 'prefer-software',
   onEncoderConfig: (config) => {
     config.avc = { ...(config.avc ?? {}), format: 'avc' };
     if (!config.latencyMode) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
-        "mediabunny": "^1.25.0",
+        "mediabunny": "^1.28.0",
         "motion": "^12.23.24",
         "next": "16.0.3",
         "react": "19.2.0",
@@ -9104,9 +9104,9 @@
       }
     },
     "node_modules/mediabunny": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.25.0.tgz",
-      "integrity": "sha512-ozaqk6zS2Vbf3+3+OoxKfnCVeZRcv5PO8DgQtBrM5vpWIbpEK+kMVV6pgfo4mC3XtMwvQEMbhj3zEf0LNklh9w==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.28.0.tgz",
+      "integrity": "sha512-D63nzvBRIBSUsRgaIfFugWCy2iOV5T/C6nHn2fW0aWqyRuSGzWsVMXzlNi3iCKieoA/WECYJg8oVGtUukpy3XQ==",
       "license": "MPL-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
-    "mediabunny": "^1.25.0",
+    "mediabunny": "^1.28.0",
     "motion": "^12.23.24",
     "next": "16.0.3",
     "react": "19.2.0",


### PR DESCRIPTION
- Bump mediabunny from 1.25.0 to 1.28.0 for Safari/Chrome stability fixes
- Add hardwareAcceleration option to video encoding config (prefer-hardware by default)

Key fixes in 1.25.8-1.28.0:
- Safari frame ordering bug fix
- Chromium key frame detection workaround
- WebKit AudioData.copyTo crash prevention