### PR TITLE
Claude/fix video rendering check 40m jw

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { LightRays } from '@/components/ui/light-rays';
 import { BlurFade } from '@/components/ui/blur-fade';
 import { FinalVideoEditor } from '@/components/FinalVideoEditor';
 import { useFinalizeVideo } from '@/hooks/useFinalizeVideo';
-import { TransitionVideo, FinalVideo, AudioProcessingOptions } from '@/lib/types';
+import { TransitionVideo, FinalVideo, AudioProcessingOptions, RenderQuality } from '@/lib/types';
 import TextPressure from '@/components/text/text-pressure';
 import { canEncodeVideo, getEncodableVideoCodecs } from 'mediabunny';
 import {
@@ -193,6 +193,8 @@ export default function Home() {
   const [isSupported, setIsSupported] = useState(true);
   const [preflightWarnings, setPreflightWarnings] = useState<PreflightWarning[]>([]);
   const [showPreflightDialog, setShowPreflightDialog] = useState(false);
+  const [renderQuality, setRenderQuality] = useState<RenderQuality>('full');
+  const [currentRenderQuality, setCurrentRenderQuality] = useState<RenderQuality | null>(null);
   const transitionVideosRef = useRef<TransitionVideo[]>([]);
 
   useEffect(() => {
@@ -488,8 +490,8 @@ export default function Home() {
     );
   };
 
-  const handleReapplyFinalVideo = async (options?: AudioFinalizeOptions) => {
-    await handleFinalizeVideo(undefined, options, true);
+  const handleReapplyFinalVideo = async (options?: AudioFinalizeOptions & { quality?: RenderQuality }) => {
+    await handleFinalizeVideo(undefined, options, true, options?.quality);
   };
 
   const runPreflightChecks = (segments: TransitionVideo[]): PreflightWarning[] => {
@@ -561,9 +563,11 @@ export default function Home() {
   const handleFinalizeVideo = async (
     segmentsOverride?: TransitionVideo[],
     options?: AudioFinalizeOptions,
-    skipPreflight: boolean = false
+    skipPreflight: boolean = false,
+    qualityOverride?: RenderQuality
   ) => {
     const baseSegments = segmentsOverride ?? transitionVideos;
+    const effectiveQuality = qualityOverride ?? renderQuality;
 
     if (!skipPreflight) {
       const warnings = runPreflightChecks(baseSegments);
@@ -577,7 +581,7 @@ export default function Home() {
     try {
       setIsFinalizingVideo(true);
       setFinalizationProgress(0);
-      setFinalizationMessage('Initializing...');
+      setFinalizationMessage(effectiveQuality === 'preview' ? 'Initializing preview render...' : 'Initializing...');
 
       const segmentsToFinalize = syncSegmentsToLoopCount(baseSegments, loopCount);
 
@@ -589,7 +593,8 @@ export default function Home() {
         },
         undefined, // Let the hook determine duration from metadata/content
         options?.audioBlob,
-        options?.audioSettings
+        options?.audioSettings,
+        effectiveQuality
       );
 
       if (!finalBlob) {
@@ -610,8 +615,9 @@ export default function Home() {
         size: finalBlob.size,
         createdAt: new Date(),
       });
+      setCurrentRenderQuality(effectiveQuality);
 
-      setFinalizationMessage('Video finalized successfully!');
+      setFinalizationMessage(effectiveQuality === 'preview' ? 'Preview ready!' : 'Video finalized successfully!');
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       console.error('Error finalizing video:', error);
@@ -753,10 +759,14 @@ export default function Home() {
                 setUploadedVideos([]);
                 setSelectedSegmentId(null);
                 setLoopCount(1);
+                setCurrentRenderQuality(null);
               }}
               onDownload={handleDownloadFinalVideo}
               loopCount={loopCount}
               onLoopCountChange={handleLoopCountChange}
+              renderQuality={renderQuality}
+              onRenderQualityChange={setRenderQuality}
+              currentRenderQuality={currentRenderQuality}
             />
 
             <Dialog open={showPreflightDialog} onOpenChange={setShowPreflightDialog}>
@@ -1061,7 +1071,21 @@ export default function Home() {
                   {/* Finalize Button for Uploaded Videos */}
                   {transitionVideos.every((v) => v.url && !v.loading) && !isFinalizingVideo && (
                     <div className="space-y-3">
-                      <div className="flex justify-center">
+                      <div className="flex flex-col items-center gap-3">
+                        <div className="flex items-center gap-2">
+                          <label htmlFor="render-quality" className="text-sm text-muted-foreground">
+                            Render Quality:
+                          </label>
+                          <select
+                            id="render-quality"
+                            value={renderQuality}
+                            onChange={(e) => setRenderQuality(e.target.value as RenderQuality)}
+                            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+                          >
+                            <option value="full">Full Quality</option>
+                            <option value="preview">Preview (720p)</option>
+                          </select>
+                        </div>
                         <Button
                           size="lg"
                           onClick={() => handleFinalizeVideo()}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ type VideoMetadata = {
 
 const FOUR_K_WIDTH = 3840;
 const FOUR_K_HEIGHT = 2160;
+const BASELINE_PIXEL_LIMIT = 1920 * 1080; // Use Level 5.1 for resolutions above 1080p
 const MAX_TOTAL_SIZE_BYTES = 1.5 * 1024 * 1024 * 1024; // 1.5GB
 
 interface PreflightWarning {
@@ -77,7 +78,7 @@ const readVideoMetadata = (file: File | Blob): Promise<VideoMetadata> =>
   });
 
 const getCodecStringForResolution = (width: number, height: number) =>
-  width >= FOUR_K_WIDTH || height >= FOUR_K_HEIGHT ? AVC_LEVEL_5_1 : AVC_LEVEL_4_0;
+  width * height > BASELINE_PIXEL_LIMIT ? AVC_LEVEL_5_1 : AVC_LEVEL_4_0;
 
 const estimateBitrateForResolution = (width: number, height: number) => {
   const pixels = width * height;

--- a/hooks/useFinalizeVideo.ts
+++ b/hooks/useFinalizeVideo.ts
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react';
 import { useApplySpeedCurve } from './useApplySpeedCurve';
 import { useStitchVideos } from './useStitchVideos';
 import { useAudioMixing } from './useAudioMixing';
-import { TransitionVideo, AudioProcessingOptions } from '@/lib/types';
+import { TransitionVideo, AudioProcessingOptions, RenderQuality } from '@/lib/types';
 import { DEFAULT_OUTPUT_DURATION, DEFAULT_EASING } from '@/lib/speed-curve-config';
 import { createBezierEasing, type EasingFunction } from '@/lib/easing-functions';
 
@@ -23,7 +23,8 @@ interface UseFinalizeVideoReturn {
     onProgress?: (progress: FinalizeProgress) => void,
     inputDuration?: number,
     audioBlob?: Blob,
-    audioSettings?: AudioProcessingOptions
+    audioSettings?: AudioProcessingOptions,
+    quality?: RenderQuality
   ) => Promise<Blob | null>;
   progress: FinalizeProgress;
   reset: () => void;
@@ -51,7 +52,8 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
       onProgress?: (progress: FinalizeProgress) => void,
       inputDuration: number = 5,
       audioBlob?: Blob,
-      audioSettings?: AudioProcessingOptions
+      audioSettings?: AudioProcessingOptions,
+      quality: RenderQuality = 'full'
     ): Promise<Blob | null> => {
       try {
         // Validate inputs
@@ -178,7 +180,9 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
                 setProgress(progressUpdate);
                 onProgress?.(progressUpdate);
               },
-              easingFunction
+              easingFunction,
+              undefined, // bitrate (let hook determine based on quality)
+              quality
             );
 
             if (!curvedBlob) {
@@ -268,7 +272,8 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
             onProgress?.(progressUpdate);
           },
           undefined, // Use default bitrate
-          audioData
+          audioData,
+          quality
         );
 
         if (!finalBlob) {

--- a/lib/speed-curve-config.ts
+++ b/lib/speed-curve-config.ts
@@ -18,6 +18,11 @@ export const MIN_SAMPLE_DURATION = 1 / 60000; // ultra-short aggregation to pres
 export const DEFAULT_BITRATE = 12_000_000; // 12 Mbps keeps quality without overloading decoders
 export const DEFAULT_KEYFRAME_INTERVAL = 0.5; // seconds between keyframes for stable seeking
 
+// Preview quality settings (720p @ 4Mbps, same framerate)
+export const PREVIEW_MAX_WIDTH = 1280;
+export const PREVIEW_MAX_HEIGHT = 720;
+export const PREVIEW_BITRATE = 4_000_000; // 4 Mbps for fast preview rendering
+
 // Speed curve parameters
 export const DEFAULT_INPUT_DURATION = 5; // Kling videos are 5 seconds
 export const DEFAULT_OUTPUT_DURATION = 1.5; // Target 1.5s with ease curve

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@
  * Shared TypeScript types for the application
  */
 
+export type RenderQuality = 'preview' | 'full';
+
 export type VideoEncodeCapabilityStatus =
   | 'pending'
   | 'checking'

--- a/lib/video-encoding.ts
+++ b/lib/video-encoding.ts
@@ -2,7 +2,8 @@ import type { VideoEncodingConfig } from 'mediabunny';
 import { DEFAULT_KEYFRAME_INTERVAL, MAX_OUTPUT_FPS } from './speed-curve-config';
 
 // Baseline profile, level 4.0 keeps reference frames minimal for Firefox forks
-export const AVC_LEVEL_4_0 = 'avc1.42C028';
+// Note: Using '00' for constraint flags instead of 'C0' for wider hardware encoder compatibility
+export const AVC_LEVEL_4_0 = 'avc1.420028';
 // High profile, level 5.1 for 4K support
 export const AVC_LEVEL_5_1 = 'avc1.640033';
 


### PR DESCRIPTION
## Summary

- **Fix false negatives in video rendering capability check** - Users with powerful computers were incorrectly being told they couldn't render videos due to overly restrictive AVC codec constraint flags
- **Add user-selectable preview quality option** - Users can now choose to render at 720p for faster iteration, with automatic full-quality re-render on download

## Changes

### Bug Fix: Video Rendering Capability Check
- Changed AVC codec string constraint flags from `C0` to `00` for wider hardware encoder compatibility
- Aligned resolution threshold logic between preflight check and actual encoding (uses pixel count > 1080p instead of 4K dimension check)

### Feature: Preview Quality Option
- Added `RenderQuality` type (`'preview'` | `'full'`)
- Preview mode renders at 720p max, 4Mbps bitrate (keeps 60fps)
- Quality selector dropdown before "Finalize & Stitch Videos" button
- Quality selector in FinalVideoEditor for re-renders
- Download button automatically triggers full-quality render if preview is currently displayed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added render quality selector enabling users to choose between Full and Preview (720p) rendering modes
  * Preview mode delivers faster rendering at 720p resolution for rapid iteration and review
  * Enhanced download workflow automatically renders full quality when needed, providing intelligent quality management during video export

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->