### PR TITLE
Merge develop: preview quality, audio caching, codec fixes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { LightRays } from '@/components/ui/light-rays';
 import { BlurFade } from '@/components/ui/blur-fade';
 import { FinalVideoEditor } from '@/components/FinalVideoEditor';
 import { useFinalizeVideo } from '@/hooks/useFinalizeVideo';
-import { TransitionVideo, FinalVideo, AudioProcessingOptions } from '@/lib/types';
+import { TransitionVideo, FinalVideo, AudioProcessingOptions, RenderQuality } from '@/lib/types';
 import TextPressure from '@/components/text/text-pressure';
 import { canEncodeVideo, getEncodableVideoCodecs } from 'mediabunny';
 import {
@@ -193,6 +193,8 @@ export default function Home() {
   const [isSupported, setIsSupported] = useState(true);
   const [preflightWarnings, setPreflightWarnings] = useState<PreflightWarning[]>([]);
   const [showPreflightDialog, setShowPreflightDialog] = useState(false);
+  const [renderQuality, setRenderQuality] = useState<RenderQuality>('full');
+  const [currentRenderQuality, setCurrentRenderQuality] = useState<RenderQuality | null>(null);
   const transitionVideosRef = useRef<TransitionVideo[]>([]);
 
   useEffect(() => {
@@ -488,8 +490,8 @@ export default function Home() {
     );
   };
 
-  const handleReapplyFinalVideo = async (options?: AudioFinalizeOptions) => {
-    await handleFinalizeVideo(undefined, options, true);
+  const handleReapplyFinalVideo = async (options?: AudioFinalizeOptions & { quality?: RenderQuality }) => {
+    await handleFinalizeVideo(undefined, options, true, options?.quality);
   };
 
   const runPreflightChecks = (segments: TransitionVideo[]): PreflightWarning[] => {
@@ -561,9 +563,11 @@ export default function Home() {
   const handleFinalizeVideo = async (
     segmentsOverride?: TransitionVideo[],
     options?: AudioFinalizeOptions,
-    skipPreflight: boolean = false
+    skipPreflight: boolean = false,
+    qualityOverride?: RenderQuality
   ) => {
     const baseSegments = segmentsOverride ?? transitionVideos;
+    const effectiveQuality = qualityOverride ?? renderQuality;
 
     if (!skipPreflight) {
       const warnings = runPreflightChecks(baseSegments);
@@ -577,7 +581,7 @@ export default function Home() {
     try {
       setIsFinalizingVideo(true);
       setFinalizationProgress(0);
-      setFinalizationMessage('Initializing...');
+      setFinalizationMessage(effectiveQuality === 'preview' ? 'Initializing preview render...' : 'Initializing...');
 
       const segmentsToFinalize = syncSegmentsToLoopCount(baseSegments, loopCount);
 
@@ -589,7 +593,8 @@ export default function Home() {
         },
         undefined, // Let the hook determine duration from metadata/content
         options?.audioBlob,
-        options?.audioSettings
+        options?.audioSettings,
+        effectiveQuality
       );
 
       if (!finalBlob) {
@@ -610,8 +615,9 @@ export default function Home() {
         size: finalBlob.size,
         createdAt: new Date(),
       });
+      setCurrentRenderQuality(effectiveQuality);
 
-      setFinalizationMessage('Video finalized successfully!');
+      setFinalizationMessage(effectiveQuality === 'preview' ? 'Preview ready!' : 'Video finalized successfully!');
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       console.error('Error finalizing video:', error);
@@ -753,10 +759,14 @@ export default function Home() {
                 setUploadedVideos([]);
                 setSelectedSegmentId(null);
                 setLoopCount(1);
+                setCurrentRenderQuality(null);
               }}
               onDownload={handleDownloadFinalVideo}
               loopCount={loopCount}
               onLoopCountChange={handleLoopCountChange}
+              renderQuality={renderQuality}
+              onRenderQualityChange={setRenderQuality}
+              currentRenderQuality={currentRenderQuality}
             />
 
             <Dialog open={showPreflightDialog} onOpenChange={setShowPreflightDialog}>
@@ -1061,7 +1071,21 @@ export default function Home() {
                   {/* Finalize Button for Uploaded Videos */}
                   {transitionVideos.every((v) => v.url && !v.loading) && !isFinalizingVideo && (
                     <div className="space-y-3">
-                      <div className="flex justify-center">
+                      <div className="flex flex-col items-center gap-3">
+                        <div className="flex items-center gap-2">
+                          <label htmlFor="render-quality" className="text-sm text-muted-foreground">
+                            Render Quality:
+                          </label>
+                          <select
+                            id="render-quality"
+                            value={renderQuality}
+                            onChange={(e) => setRenderQuality(e.target.value as RenderQuality)}
+                            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+                          >
+                            <option value="full">Full Quality</option>
+                            <option value="preview">Preview (720p)</option>
+                          </select>
+                        </div>
                         <Button
                           size="lg"
                           onClick={() => handleFinalizeVideo()}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -193,7 +193,7 @@ export default function Home() {
   const [isSupported, setIsSupported] = useState(true);
   const [preflightWarnings, setPreflightWarnings] = useState<PreflightWarning[]>([]);
   const [showPreflightDialog, setShowPreflightDialog] = useState(false);
-  const [renderQuality, setRenderQuality] = useState<RenderQuality>('full');
+  const [renderQuality, setRenderQuality] = useState<RenderQuality>('preview');
   const [currentRenderQuality, setCurrentRenderQuality] = useState<RenderQuality | null>(null);
   const transitionVideosRef = useRef<TransitionVideo[]>([]);
 
@@ -1072,20 +1072,15 @@ export default function Home() {
                   {transitionVideos.every((v) => v.url && !v.loading) && !isFinalizingVideo && (
                     <div className="space-y-3">
                       <div className="flex flex-col items-center gap-3">
-                        <div className="flex items-center gap-2">
-                          <label htmlFor="render-quality" className="text-sm text-muted-foreground">
-                            Render Quality:
-                          </label>
-                          <select
-                            id="render-quality"
-                            value={renderQuality}
-                            onChange={(e) => setRenderQuality(e.target.value as RenderQuality)}
-                            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm"
-                          >
-                            <option value="full">Full Quality</option>
-                            <option value="preview">Preview (720p)</option>
-                          </select>
-                        </div>
+                        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <input
+                            type="checkbox"
+                            checked={renderQuality === 'preview'}
+                            onChange={(e) => setRenderQuality(e.target.checked ? 'preview' : 'full')}
+                            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                          />
+                          Render previews in lower quality (faster)
+                        </label>
                         <Button
                           size="lg"
                           onClick={() => handleFinalizeVideo()}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,7 @@ type VideoMetadata = {
 
 const FOUR_K_WIDTH = 3840;
 const FOUR_K_HEIGHT = 2160;
+const BASELINE_PIXEL_LIMIT = 1920 * 1080; // Use Level 5.1 for resolutions above 1080p
 const MAX_TOTAL_SIZE_BYTES = 1.5 * 1024 * 1024 * 1024; // 1.5GB
 
 interface PreflightWarning {
@@ -77,7 +78,7 @@ const readVideoMetadata = (file: File | Blob): Promise<VideoMetadata> =>
   });
 
 const getCodecStringForResolution = (width: number, height: number) =>
-  width >= FOUR_K_WIDTH || height >= FOUR_K_HEIGHT ? AVC_LEVEL_5_1 : AVC_LEVEL_4_0;
+  width * height > BASELINE_PIXEL_LIMIT ? AVC_LEVEL_5_1 : AVC_LEVEL_4_0;
 
 const estimateBitrateForResolution = (width: number, height: number) => {
   const pixels = width * height;

--- a/components/FinalVideoEditor.tsx
+++ b/components/FinalVideoEditor.tsx
@@ -308,7 +308,7 @@ function FinalVideoEditorComponent({
     ? 'Rendering Full Quality...'
     : isPreviewRender
     ? 'Download (Render Full Quality)'
-    : 'Download';
+    : 'Download (full quality)';
 
   const ExportButtons = (
     <div className="flex gap-2">

--- a/components/FinalVideoEditor.tsx
+++ b/components/FinalVideoEditor.tsx
@@ -495,20 +495,15 @@ function FinalVideoEditorComponent({
           />
           Apply settings to all videos
         </label>
-        <div className="flex items-center gap-2 mt-2">
-          <label htmlFor="update-quality" className="text-sm text-muted-foreground whitespace-nowrap">
-            Quality:
-          </label>
-          <select
-            id="update-quality"
-            value={renderQuality}
-            onChange={(e) => onRenderQualityChange(e.target.value as RenderQuality)}
-            className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-sm"
-          >
-            <option value="full">Full Quality</option>
-            <option value="preview">Preview (720p)</option>
-          </select>
-        </div>
+        <label className="flex items-center gap-2 text-sm text-muted-foreground mt-4">
+          <input
+            type="checkbox"
+            checked={renderQuality === 'preview'}
+            onChange={(e) => onRenderQualityChange(e.target.checked ? 'preview' : 'full')}
+            className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+          />
+          Render previews in lower quality (faster)
+        </label>
         <Button
           size="sm"
           onClick={() => handleVideoUpdate()}

--- a/hooks/useFinalizeVideo.ts
+++ b/hooks/useFinalizeVideo.ts
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react';
 import { useApplySpeedCurve } from './useApplySpeedCurve';
 import { useStitchVideos } from './useStitchVideos';
 import { useAudioMixing } from './useAudioMixing';
-import { TransitionVideo, AudioProcessingOptions } from '@/lib/types';
+import { TransitionVideo, AudioProcessingOptions, RenderQuality } from '@/lib/types';
 import { DEFAULT_OUTPUT_DURATION, DEFAULT_EASING } from '@/lib/speed-curve-config';
 import { createBezierEasing, type EasingFunction } from '@/lib/easing-functions';
 
@@ -23,7 +23,8 @@ interface UseFinalizeVideoReturn {
     onProgress?: (progress: FinalizeProgress) => void,
     inputDuration?: number,
     audioBlob?: Blob,
-    audioSettings?: AudioProcessingOptions
+    audioSettings?: AudioProcessingOptions,
+    quality?: RenderQuality
   ) => Promise<Blob | null>;
   progress: FinalizeProgress;
   reset: () => void;
@@ -51,7 +52,8 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
       onProgress?: (progress: FinalizeProgress) => void,
       inputDuration: number = 5,
       audioBlob?: Blob,
-      audioSettings?: AudioProcessingOptions
+      audioSettings?: AudioProcessingOptions,
+      quality: RenderQuality = 'full'
     ): Promise<Blob | null> => {
       try {
         // Validate inputs
@@ -178,7 +180,9 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
                 setProgress(progressUpdate);
                 onProgress?.(progressUpdate);
               },
-              easingFunction
+              easingFunction,
+              undefined, // bitrate (let hook determine based on quality)
+              quality
             );
 
             if (!curvedBlob) {
@@ -268,7 +272,8 @@ export const useFinalizeVideo = (): UseFinalizeVideoReturn => {
             onProgress?.(progressUpdate);
           },
           undefined, // Use default bitrate
-          audioData
+          audioData,
+          quality
         );
 
         if (!finalBlob) {

--- a/hooks/useRemuxAudio.ts
+++ b/hooks/useRemuxAudio.ts
@@ -216,7 +216,7 @@ export const useRemuxAudio = (): UseRemuxAudioReturn => {
         const videoSource = new EncodedVideoPacketSource(videoCodec);
 
         // Detect best audio codec
-        const audioCodec = await getFirstEncodableAudioCodec(['aac', 'opus', 'mp3'], {
+        const audioCodec = await getFirstEncodableAudioCodec(['aac', 'mp3'], {
           numberOfChannels: channels,
           sampleRate,
           bitrate: 128000,

--- a/hooks/useStitchVideos.ts
+++ b/hooks/useStitchVideos.ts
@@ -284,8 +284,8 @@ export const useStitchVideos = (): UseStitchVideosReturn => {
           updateProgress('processing', 'Detecting supported audio codec...', 8);
 
           // Detect the best supported audio codec for MP4
-          // Try common codecs in order of preference: aac, opus, mp3
-          const audioCodec = await getFirstEncodableAudioCodec(['aac', 'opus', 'mp3'], {
+          // Try common codecs in order of preference: aac, mp3 (no opus - Twitter doesn't support it)
+          const audioCodec = await getFirstEncodableAudioCodec(['aac', 'mp3'], {
             numberOfChannels: audioData.buffer.numberOfChannels,
             sampleRate: audioData.buffer.sampleRate,
             bitrate: 128000,

--- a/lib/speed-curve-config.ts
+++ b/lib/speed-curve-config.ts
@@ -18,6 +18,11 @@ export const MIN_SAMPLE_DURATION = 1 / 60000; // ultra-short aggregation to pres
 export const DEFAULT_BITRATE = 12_000_000; // 12 Mbps keeps quality without overloading decoders
 export const DEFAULT_KEYFRAME_INTERVAL = 0.5; // seconds between keyframes for stable seeking
 
+// Preview quality settings (720p @ 4Mbps, same framerate)
+export const PREVIEW_MAX_WIDTH = 1280;
+export const PREVIEW_MAX_HEIGHT = 720;
+export const PREVIEW_BITRATE = 4_000_000; // 4 Mbps for fast preview rendering
+
 // Speed curve parameters
 export const DEFAULT_INPUT_DURATION = 5; // Kling videos are 5 seconds
 export const DEFAULT_OUTPUT_DURATION = 1.5; // Target 1.5s with ease curve

--- a/lib/speed-curve-config.ts
+++ b/lib/speed-curve-config.ts
@@ -7,9 +7,9 @@
 export const TARGET_FRAME_RATE = 30; // 30 fps source
 export const TARGET_FRAME_DURATION = 1 / TARGET_FRAME_RATE; // ~0.0333s
 
-// Output constraints - high fps for smooth ease curve transitions and quality
-export const MAX_OUTPUT_FPS = 60; // 60 fps output for smooth easing
-export const MIN_OUTPUT_FRAME_DURATION = 1 / MAX_OUTPUT_FPS; // ~0.0167s
+// Output constraints - fps for preview rendering
+export const MAX_OUTPUT_FPS = 30; // 30 fps output for preview
+export const MIN_OUTPUT_FRAME_DURATION = 1 / MAX_OUTPUT_FPS; // ~0.0333s
 
 // Sample aggregation thresholds
 export const MIN_SAMPLE_DURATION = 1 / 60000; // ultra-short aggregation to preserve eased ramps

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,6 +2,8 @@
  * Shared TypeScript types for the application
  */
 
+export type RenderQuality = 'preview' | 'full';
+
 export type VideoEncodeCapabilityStatus =
   | 'pending'
   | 'checking'

--- a/lib/video-encoding.ts
+++ b/lib/video-encoding.ts
@@ -16,7 +16,8 @@ export const createAvcEncodingConfig = (
   width?: number,
   height?: number,
   codecString: string = AVC_LEVEL_4_0,
-  framerate?: number
+  framerate?: number,
+  useHardwareAcceleration: boolean = true
 ): VideoEncodingConfig => ({
   codec: 'avc',
   bitrate,
@@ -24,6 +25,7 @@ export const createAvcEncodingConfig = (
   bitrateMode: 'variable',
   latencyMode: 'quality',
   fullCodecString: codecString,
+  hardwareAcceleration: useHardwareAcceleration ? 'prefer-hardware' : 'prefer-software',
   onEncoderConfig: (config) => {
     config.avc = { ...(config.avc ?? {}), format: 'avc' };
     if (!config.latencyMode) {

--- a/lib/video-encoding.ts
+++ b/lib/video-encoding.ts
@@ -2,7 +2,8 @@ import type { VideoEncodingConfig } from 'mediabunny';
 import { DEFAULT_KEYFRAME_INTERVAL, MAX_OUTPUT_FPS } from './speed-curve-config';
 
 // Baseline profile, level 4.0 keeps reference frames minimal for Firefox forks
-export const AVC_LEVEL_4_0 = 'avc1.42C028';
+// Note: Using '00' for constraint flags instead of 'C0' for wider hardware encoder compatibility
+export const AVC_LEVEL_4_0 = 'avc1.420028';
 // High profile, level 5.1 for 4K support
 export const AVC_LEVEL_5_1 = 'avc1.640033';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
-        "mediabunny": "^1.25.0",
+        "mediabunny": "^1.28.0",
         "motion": "^12.23.24",
         "next": "16.0.3",
         "react": "19.2.0",
@@ -9104,9 +9104,9 @@
       }
     },
     "node_modules/mediabunny": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.25.0.tgz",
-      "integrity": "sha512-ozaqk6zS2Vbf3+3+OoxKfnCVeZRcv5PO8DgQtBrM5vpWIbpEK+kMVV6pgfo4mC3XtMwvQEMbhj3zEf0LNklh9w==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.28.0.tgz",
+      "integrity": "sha512-D63nzvBRIBSUsRgaIfFugWCy2iOV5T/C6nHn2fW0aWqyRuSGzWsVMXzlNi3iCKieoA/WECYJg8oVGtUukpy3XQ==",
       "license": "MPL-2.0",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "lucide-react": "^0.553.0",
         "mediabunny": "^1.28.0",
         "motion": "^12.23.24",
-        "next": "16.0.3",
+        "next": "16.0.10",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "tailwind-merge": "^3.4.0"
@@ -34,7 +34,7 @@
         "@types/react-dom": "^19",
         "concurrently": "^9.2.1",
         "eslint": "^9",
-        "eslint-config-next": "16.0.3",
+        "eslint-config-next": "16.0.10",
         "jsdom": "^27.0.1",
         "shadcn": "^3.5.0",
         "tailwindcss": "^4",
@@ -2317,15 +2317,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.3.tgz",
-      "integrity": "sha512-IqgtY5Vwsm14mm/nmQaRMmywCU+yyMIYfk3/MHZ2ZTJvwVbBn3usZnjMi1GacrMVzVcAxJShTCpZlPs26EdEjQ==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.10.tgz",
+      "integrity": "sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.3.tgz",
-      "integrity": "sha512-6sPWmZetzFWMsz7Dhuxsdmbu3fK+/AxKRtj7OB0/3OZAI2MHB/v2FeYh271LZ9abvnM1WIwWc/5umYjx0jo5sQ==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.10.tgz",
+      "integrity": "sha512-b2NlWN70bbPLmfyoLvvidPKWENBYYIe017ZGUpElvQjDytCWgxPJx7L9juxHt0xHvNVA08ZHJdOyhGzon/KJuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2333,9 +2333,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.3.tgz",
-      "integrity": "sha512-MOnbd92+OByu0p6QBAzq1ahVWzF6nyfiH07dQDez4/Nku7G249NjxDVyEfVhz8WkLiOEU+KFVnqtgcsfP2nLXg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.10.tgz",
+      "integrity": "sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==",
       "cpu": [
         "arm64"
       ],
@@ -2349,9 +2349,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.3.tgz",
-      "integrity": "sha512-i70C4O1VmbTivYdRlk+5lj9xRc2BlK3oUikt3yJeHT1unL4LsNtN7UiOhVanFdc7vDAgZn1tV/9mQwMkWOJvHg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.10.tgz",
+      "integrity": "sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==",
       "cpu": [
         "x64"
       ],
@@ -2365,9 +2365,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.3.tgz",
-      "integrity": "sha512-O88gCZ95sScwD00mn/AtalyCoykhhlokxH/wi1huFK+rmiP5LAYVs/i2ruk7xST6SuXN4NI5y4Xf5vepb2jf6A==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.10.tgz",
+      "integrity": "sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==",
       "cpu": [
         "arm64"
       ],
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.3.tgz",
-      "integrity": "sha512-CEErFt78S/zYXzFIiv18iQCbRbLgBluS8z1TNDQoyPi8/Jr5qhR3e8XHAIxVxPBjDbEMITprqELVc5KTfFj0gg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.10.tgz",
+      "integrity": "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==",
       "cpu": [
         "arm64"
       ],
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.3.tgz",
-      "integrity": "sha512-Tc3i+nwt6mQ+Dwzcri/WNDj56iWdycGVh5YwwklleClzPzz7UpfaMw1ci7bLl6GRYMXhWDBfe707EXNjKtiswQ==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.10.tgz",
+      "integrity": "sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==",
       "cpu": [
         "x64"
       ],
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.3.tgz",
-      "integrity": "sha512-zTh03Z/5PBBPdTurgEtr6nY0vI9KR9Ifp/jZCcHlODzwVOEKcKRBtQIGrkc7izFgOMuXDEJBmirwpGqdM/ZixA==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.10.tgz",
+      "integrity": "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==",
       "cpu": [
         "x64"
       ],
@@ -2429,9 +2429,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.3.tgz",
-      "integrity": "sha512-Jc1EHxtZovcJcg5zU43X3tuqzl/sS+CmLgjRP28ZT4vk869Ncm2NoF8qSTaL99gh6uOzgM99Shct06pSO6kA6g==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.10.tgz",
+      "integrity": "sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==",
       "cpu": [
         "arm64"
       ],
@@ -2445,9 +2445,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.3.tgz",
-      "integrity": "sha512-N7EJ6zbxgIYpI/sWNzpVKRMbfEGgsWuOIvzkML7wxAAZhPk1Msxuo/JDu1PKjWGrAoOLaZcIX5s+/pF5LIbBBg==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.10.tgz",
+      "integrity": "sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==",
       "cpu": [
         "x64"
       ],
@@ -6515,13 +6515,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.3.tgz",
-      "integrity": "sha512-5F6qDjcZldf0Y0ZbqvWvap9xzYUxyDf7/of37aeyhvkrQokj/4bT1JYWZdlWUr283aeVa+s52mPq9ogmGg+5dw==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.10.tgz",
+      "integrity": "sha512-BxouZUm0I45K4yjOOIzj24nTi0H2cGo0y7xUmk+Po/PYtJXFBYVDS1BguE7t28efXjKdcN0tmiLivxQy//SsZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.0.3",
+        "@next/eslint-plugin-next": "16.0.10",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -9408,12 +9408,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.3.tgz",
-      "integrity": "sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==",
+      "version": "16.0.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.10.tgz",
+      "integrity": "sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.3",
+        "@next/env": "16.0.10",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -9426,14 +9426,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.3",
-        "@next/swc-darwin-x64": "16.0.3",
-        "@next/swc-linux-arm64-gnu": "16.0.3",
-        "@next/swc-linux-arm64-musl": "16.0.3",
-        "@next/swc-linux-x64-gnu": "16.0.3",
-        "@next/swc-linux-x64-musl": "16.0.3",
-        "@next/swc-win32-arm64-msvc": "16.0.3",
-        "@next/swc-win32-x64-msvc": "16.0.3",
+        "@next/swc-darwin-arm64": "16.0.10",
+        "@next/swc-darwin-x64": "16.0.10",
+        "@next/swc-linux-arm64-gnu": "16.0.10",
+        "@next/swc-linux-arm64-musl": "16.0.10",
+        "@next/swc-linux-x64-gnu": "16.0.10",
+        "@next/swc-linux-x64-musl": "16.0.10",
+        "@next/swc-win32-arm64-msvc": "16.0.10",
+        "@next/swc-win32-x64-msvc": "16.0.10",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
-    "mediabunny": "^1.25.0",
+    "mediabunny": "^1.28.0",
     "motion": "^12.23.24",
     "next": "16.0.3",
     "react": "19.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lucide-react": "^0.553.0",
     "mediabunny": "^1.28.0",
     "motion": "^12.23.24",
-    "next": "16.0.3",
+    "next": "16.0.10",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "tailwind-merge": "^3.4.0"
@@ -37,7 +37,7 @@
     "@types/react-dom": "^19",
     "concurrently": "^9.2.1",
     "eslint": "^9",
-    "eslint-config-next": "16.0.3",
+    "eslint-config-next": "16.0.10",
     "jsdom": "^27.0.1",
     "shadcn": "^3.5.0",
     "tailwindcss": "^4",


### PR DESCRIPTION
## Summary

- **Preview quality mode**: 720p @ 30fps @ 4Mbps for faster preview rendering
- **Full quality mode**: 60fps with preserved source bitrate for smooth easing
- **Audio caching fast path**: Skip re-processing video when only audio settings change
- **Hardware-compatible codec**: Use `avc1.420028` for wider encoder support
- **Twitter compatibility**: Remove opus from audio codec fallback (aac → mp3 only)
- **MediaBunny 1.28.0**: Upgrade with hardware acceleration support
- **UI improvements**: Checkbox-based render quality selection

## Test plan
- [ ] Render a preview video - should be 720p @ 30fps
- [ ] Render full quality - should be original resolution @ 60fps
- [ ] Change audio fade settings - should use fast remux path
- [ ] Upload to Twitter - audio should work (no opus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added render quality toggle allowing you to choose between preview (lower quality, faster rendering) and full quality modes during video editing and export

* **Performance Improvements**
  * Preview rendering mode now available with optimized 720p resolution and encoding for significantly faster processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->